### PR TITLE
Adding GitHub Actions - avoid dup bet

### DIFF
--- a/.github/workflows/avoid_dup_bet.yml
+++ b/.github/workflows/avoid_dup_bet.yml
@@ -1,0 +1,42 @@
+name: Avoid Duplicated BET
+
+on:
+  push:
+    branches:
+    - main
+    - '**feature**'
+    - '**feat**'
+    - '**bugfix**'
+    - '**fix**'
+    - '**release**'
+  pull_request:
+    branches:
+    - main
+    - '**feature**'
+    - '**feat**'
+    - '**bugfix**'
+    - '**fix**'
+    - '**release**'
+
+jobs:
+  check-duplicates:
+    runs-on: ubuntu-latest
+    defaults:
+        run:
+          working-directory: ./_cicd/
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+
+      - name: Avoid Duplicated BET at Blocked List
+        run: |
+          python avoid_dup_bet.py

--- a/_cicd/avoid_dup_bet.py
+++ b/_cicd/avoid_dup_bet.py
@@ -1,0 +1,31 @@
+# **************************************************************************** #
+#                                                                              #
+#                                                         :::      ::::::::    #
+#    avoid_dup_bet.py                                   :+:      :+:    :+:    #
+#                                                     +:+ +:+         +:+      #
+#    By: umeneses <umeneses@student.42.fr>          +#+  +:+       +#+         #
+#                                                 +#+#+#+#+#+   +#+            #
+#    Created: 2024/11/06 08:12:15 by umeneses          #+#    #+#              #
+#    Updated: 2024/11/06 08:25:53 by umeneses         ###   ########.fr        #
+#                                                                              #
+# **************************************************************************** #
+
+import sys
+
+def check_duplicates_bets(file_path):
+    with open(file_path, 'r') as file:
+        lines = file.read().splitlines()
+    
+    seen = {}
+    for line_number, line in enumerate(lines, start=1):
+        if line in seen:
+            print(f"Duplicated BET found on line {line_number}: '{line}'")
+            sys.exit(line_number)
+        seen[line] = line_number
+
+    print("No duplicates found.")
+    sys.exit(0)
+
+if __name__ == "__main__":
+    check_duplicates_bets('../blocklist.txt')
+

--- a/blocklist.txt
+++ b/blocklist.txt
@@ -793,7 +793,6 @@ boylesports.com
 br.1xbet.com
 br.888casino.com
 br.betcris.com
-br.betcris.com
 br.magicred.com
 br.melbet.com
 br.mrplay.com


### PR DESCRIPTION
## The problem:
We have a lot of upcoming new site BET everyday.
Nowadays, the `blocklist` has more then 2000 sites.
So, the is a highly chance of a duplicated BET.

## The solution:
This GitHub Actions will detects if there is a duplicated BET.
If so, it fails showing the `line number` that needs to be fixed.